### PR TITLE
allow users to specify classes or ids

### DIFF
--- a/src/regulate.js
+++ b/src/regulate.js
@@ -560,7 +560,14 @@ if (this.jQuery === undefined) {
     self.cb = cb;
     self.isBrowser = true;
 
-    $(root.document).on('submit', '#' + self.name, function (e) {
+    var name;
+    if(self.name[0] === '#' ||  self.name[0] === "." ) {
+      name = self.name;
+    }else{ // this line gives backwards compatibility
+      name = "#" + self.name;
+    }
+
+    $(root.document).on('submit', name, function (e) {
       e.preventDefault();
 
       // Clear previous errors


### PR DESCRIPTION
Update that allows the specification of form based on class or id explicitly. You can give "#<id-str>" or ".<class-str>". You can still give just a string with no modifier and it will assume that an id is wanted. This preserves backwards compatibility. 

Deals with Issue #6. 
